### PR TITLE
Fix normalizing ZDT with granularity

### DIFF
--- a/modules/scalacheck-toolbox-datetime/src/main/scala/com/fortysevendeg/scalacheck/datetime/jdk8/GenJdk8.scala
+++ b/modules/scalacheck-toolbox-datetime/src/main/scala/com/fortysevendeg/scalacheck/datetime/jdk8/GenJdk8.scala
@@ -62,7 +62,7 @@ object ArbitraryJdk8 extends GenJdk8 {
   implicit def arbZonedDateTimeJdk8(implicit
       granularity: Granularity[ZonedDateTime]
   ): Arbitrary[ZonedDateTime] =
-    Arbitrary(genZonedDateTime)
+    Arbitrary(genZonedDateTime.map(granularity.normalize))
 
   implicit def arbLocalDateTimeJdk8(implicit
       granularity: Granularity[ZonedDateTime]


### PR DESCRIPTION
For some reason it appears that ZDTs are not normalized properly, causing a failure in the test suite that has prevented automatic dependency updates and broken CI for about a month. This change ensures that normalizing ZDTs is applied appropriately.