### PR TITLE
Bump deps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ lazy val `scalacheck-toolbox-datetime`: ProjectMatrix =
     .jsPlatform(
       scalaVersions = allScalaVersions,
       settings = Seq(
-        libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.4.0" % Test
+        libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.5.0" % Test
       )
     )
 

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,8 @@ lazy val `scalacheck-toolbox-datetime`: ProjectMatrix =
       libraryDependencies ++= Seq(
         "org.scalacheck"         %%% "scalacheck"              % "1.17.0",
         "org.scala-lang.modules" %%% "scala-collection-compat" % "2.9.0"
-      )
+      ),
+      scalacOptions --= Seq("-Werror", "-Xfatal-warnings")
     )
     .jvmPlatform(
       scalaVersions = allScalaVersions,
@@ -65,11 +66,13 @@ lazy val `scalacheck-toolbox-magic`: ProjectMatrix =
     .enablePlugins(BigListOfNaughtyStringsPlugin)
     .settings(description := "ScalaCheck Generators for magic values")
     .settings(libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.17.0")
+    .settings(scalacOptions --= Seq("-Werror", "-Xfatal-warnings"))
     .jvmPlatform(scalaVersions = allScalaVersions)
 
 lazy val `scalacheck-toolbox-combinators`: ProjectMatrix =
   (projectMatrix in file("modules/scalacheck-toolbox-combinators"))
     .settings(description := "Useful generic combinators for ScalaCheck")
     .settings(libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.17.0")
+    .settings(scalacOptions --= Seq("-Werror", "-Xfatal-warnings"))
     .jvmPlatform(scalaVersions = allScalaVersions)
     .jsPlatform(scalaVersions = allScalaVersions)

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,8 @@ lazy val microsite = project
   )
   .settings(
     publish / skip := true,
-    unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(
+    scalacOptions --= Seq("-Werror", "-Xfatal-warnings"),
+    ScalaUnidoc / unidoc / unidocProjectFilter := inProjects(
       Seq(
         `scalacheck-toolbox-datetime`.jvm(scala2_13),
         `scalacheck-toolbox-magic`.jvm(scala2_13),

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ lazy val `scalacheck-toolbox-datetime`: ProjectMatrix =
     .settings(
       libraryDependencies ++= Seq(
         "org.scalacheck"         %%% "scalacheck"              % "1.17.0",
-        "org.scala-lang.modules" %%% "scala-collection-compat" % "2.8.1"
+        "org.scala-lang.modules" %%% "scala-collection-compat" % "2.9.0"
       )
     )
     .jvmPlatform(

--- a/microsite/docs/docs/datetime/granularity.md
+++ b/microsite/docs/docs/datetime/granularity.md
@@ -28,7 +28,7 @@ import com.fortysevendeg.scalacheck.datetime.jdk8.ArbitraryJdk8._
 import com.fortysevendeg.scalacheck.datetime.jdk8.granularity.years
 
 val prop = forAll { (zdt: ZonedDateTime) =>
-  (zdt.getMonth == Month.JANUARY)
+  (zdt.getMonth == Month.JANUARY) &&
   (zdt.getDayOfMonth == 1) &&
   (zdt.getHour == 0) &&
   (zdt.getMinute == 0) &&

--- a/project/MicrositeSettingsPlugin.scala
+++ b/project/MicrositeSettingsPlugin.scala
@@ -31,10 +31,10 @@ object MicrositeSettingsPlugin extends AutoPlugin {
       micrositePushSiteWith     := GitHub4s,
       micrositeTheme            := "pattern",
       micrositeGithubToken      := Option(System.getenv().get("GITHUB_TOKEN")),
-      docsMappingsAPIDir in ScalaUnidoc := "api",
+      ScalaUnidoc / docsMappingsAPIDir := "api",
       addMappingsToSiteDir(
-        mappings in (ScalaUnidoc, packageDoc),
-        docsMappingsAPIDir in ScalaUnidoc
+        ScalaUnidoc / packageDoc / mappings,
+        ScalaUnidoc / docsMappingsAPIDir
       )
     )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,6 +8,6 @@ addSbtPlugin("com.alejandrohdezma"       % "sbt-github"               % "0.11.6"
 addSbtPlugin("com.alejandrohdezma"       % "sbt-github-header"        % "0.11.6")
 addSbtPlugin("com.alejandrohdezma"       % "sbt-github-mdoc"          % "0.11.6")
 addSbtPlugin("com.alejandrohdezma"       % "sbt-remove-test-from-pom" % "0.1.0")
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"             % "0.4.1")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"             % "0.4.2")
 addSbtPlugin("com.eed3si9n"              % "sbt-projectmatrix"        % "0.9.0")
 addSbtPlugin("org.scala-js"              % "sbt-scalajs"              % "1.13.0")


### PR DESCRIPTION
Getting some odd warnings on properties. Disabling the warnings for unblocking the release:

```
[warn]   modules/scalacheck-toolbox-magic/src/test/scala/com/fortysevendeg/scalacheck/magic/MagicProperties.scala:29:53: unused value of type scala.collection.mutable.ListBuffer[(String, org.scalacheck.Prop)] (add `: Unit` to discard silently)
[warn]   property("magic strings are generated correctly") = forAll(magicStrings) { s =>
```